### PR TITLE
Add path like objects as output file for casanova writer

### DIFF
--- a/test/writer_test.py
+++ b/test/writer_test.py
@@ -235,3 +235,13 @@ class TestWriter(object):
 
         with pytest.raises(TypeError, match="expect"):
             writer.writerow(["one", "two", "three"])
+
+    def test_close(self):
+        buf = StringIO()
+        writer = Writer(buf, fieldnames=["test1", "test2"])
+
+        with pytest.raises(NotImplementedError, match="cannot close a file this instance did not open"):
+            writer.close()
+
+        with Writer(buf, fieldnames=["test1", "test2"]) as writer:
+            pass


### PR DESCRIPTION
This PR allows user to mention a string path (or Path instance) as output file for casanova's writer. Before, only file or buffer were accepted. Consequential changes are :

- a new `encoding` and `open_mode` kwargs for `Writer`
- `_enter_()`, `_exit_()` and `close()` as new methods
- a small unit test to ensure `close()` method is called properly 